### PR TITLE
Add Hit and Sunk methods to Ship class

### DIFF
--- a/lib/ship.rb
+++ b/lib/ship.rb
@@ -5,7 +5,11 @@ class Ship
     @name = name
     @health = health
     @length = health
+    @sunk = false
   end
 
+  def sunk?
+    @sunk
+  end
 
 end

--- a/lib/ship.rb
+++ b/lib/ship.rb
@@ -14,6 +14,7 @@ class Ship
 
   def hit
     @health -= 1
+    @sunk = true ? @health == 0 : false
   end
 
 end

--- a/lib/ship.rb
+++ b/lib/ship.rb
@@ -12,4 +12,8 @@ class Ship
     @sunk
   end
 
+  def hit
+    @health -= 1
+  end
+
 end

--- a/test/ship_test.rb
+++ b/test/ship_test.rb
@@ -28,7 +28,6 @@ class ShipTest < Minitest::Test
 
   # test if the ship has been hit
   def test_if_ship_has_been_hit_once
-    skip
     @cruiser.hit
     assert_equal 2, @cruiser.health
     refute @cruiser.sunk?
@@ -36,7 +35,6 @@ class ShipTest < Minitest::Test
 
   # test if the ship has been hit twice
   def test_if_ship_has_been_hit_twice
-    skip
     @cruiser.hit
     @cruiser.hit
     assert_equal 1, @cruiser.health
@@ -45,7 +43,6 @@ class ShipTest < Minitest::Test
 
   # test if the ship has been hit thrice
   def test_if_ship_has_been_hit_thrice
-    skip
     @cruiser.hit
     @cruiser.hit
     @cruiser.hit
@@ -54,7 +51,6 @@ class ShipTest < Minitest::Test
 
   # test if the ship has sunk with no health
   def test_if_ship_is_sunk_with_no_health
-    skip
     @cruiser.hit
     @cruiser.hit
     @cruiser.hit

--- a/test/ship_test.rb
+++ b/test/ship_test.rb
@@ -23,7 +23,6 @@ class ShipTest < Minitest::Test
 
   # test if the ship has been sunk
   def test_if_ship_has_sunk
-    skip
     refute @cruiser.sunk?
   end
 

--- a/test/ship_test.rb
+++ b/test/ship_test.rb
@@ -12,9 +12,6 @@ class ShipTest < Minitest::Test
   # test Ship class initialize
   def test_it_exists
     assert_instance_of Ship, @cruiser
-    assert_equal "Cruiser", @cruiser.name
-    assert_equal 3, @cruiser.length
-    assert_equal 3, @cruiser.health
   end
 
   # test if ship has attributes


### PR DESCRIPTION
## What does this PR do?
--
I have implemented the:
`sunk` attribute starting as false by default
`hit` method that reduces the `health` of the Ship by 1 each time it is used on a ship
`hit` method logic to confirm and change the `sunk` status to true if `health` is 0

I also found that the 'it exists' test had redundant code from our 'attributes' test, so I removed that code.