### PR TITLE
Add init and attr tests for Cell class

### DIFF
--- a/test/cell_test.rb
+++ b/test/cell_test.rb
@@ -1,0 +1,26 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+require './lib/cell'
+require './lib/ship'
+class CellTest < Minitest::Test
+  def setup
+    @cell = Cell.new("B4")
+    @ship = Ship.new("Cruiser", 3)
+  end
+
+  def test_it_exists
+    assert_instance_of Cell, @cell
+  end
+
+  def test_it_has_a_coordinate
+    assert_equal "B4", @cell.coordinate
+  end
+
+  def test_it_does_not_have_a_ship_by_default
+    assert_nil @cell.ship
+  end
+
+  def test_it_is_empty_by_default
+    assert @cell.empty?
+  end
+end


### PR DESCRIPTION
What does this PR do?
--
This implements the `initialize` method for the Cell class, including the `coordinate` argument.
A Cell will not have a Ship by default, and the Ship will not exist. The attr should return nil.
A Cell will be empty by default, as it does not have a Ship inside of it.