### PR TITLE
Add 'fire_upon' tests to Cell tests

### DIFF
--- a/test/cell_test.rb
+++ b/test/cell_test.rb
@@ -33,4 +33,20 @@ class CellTest < Minitest::Test
     @cell.place_ship(@ship)
     refute @cell.empty?
   end
+
+  def test_it_is_not_fired_upon_by_default
+    refute @cell.fired_upon?
+  end
+
+  def test_fire_upon_reduces_a_placed_ships_health
+    @cell.place_ship(@ship)
+    @cell.fire_upon
+
+    assert_equal 2, @cell.ship.health
+  end
+
+  def test_fire_upon_updates_fired_upon_to_true
+    @cell.fire_upon
+    assert @cell.fired_upon?
+  end
 end


### PR DESCRIPTION
What does this PR do?
--
These tests will test the functionality of the `fire_upon` method inside of Cell, which should reduce the `health` attribute of the Ship by 1, and also change the status of `fired_upon` to `true`. We should be able to find this boolean value through the `fired_upon?` method.