### PR TITLE
Add 'render' method tests

### DIFF
--- a/test/cell_test.rb
+++ b/test/cell_test.rb
@@ -49,4 +49,34 @@ class CellTest < Minitest::Test
     @cell.fire_upon
     assert @cell.fired_upon?
   end
+
+  def test_it_displays_a_dot_if_it_has_not_been_fired_upon
+    assert_equal ".", @cell.render
+  end
+
+  def test_it_displays_an_m_if_it_has_been_fired_upon_with_no_ship
+    @cell.fire_upon
+
+    assert_equal "M", @cell.render
+  end
+
+  def test_it_displays_a_dot_after_placing_a_ship
+    @cell.place_ship(@ship)
+
+    assert_equal ".", @cell.render
+  end
+
+  def test_it_displays_an_s_if_it_has_a_ship_with_render_true_argument
+    @cell.place_ship(@ship)
+    @cell.render(true)
+
+    assert_equal "S", @cell.render
+  end
+
+  def test_it_displays_an_h_if_it_has_a_ship_and_is_fired_upon
+    @cell.place_ship(@ship)
+    @cell.fire_upon
+
+    assert_equal "H", @cell.render
+  end
 end


### PR DESCRIPTION
What does this PR do?
--
This will test the `render` method for the Cell class. 
- A Cell should render "." by default, regardless of having a Ship or not.
- A Cell should `render` an "M" after having been `fired_upon` without a Ship.
- A Cell should `render` an "S" if it has a Ship, and we are checking/debugging where our Ships are.
- A Cell should `render` an "H" if it has a Ship, and it has been `fired_upon`.