### PR TITLE
Board.place method, overlap placement test

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -65,5 +65,11 @@ class Board
 		end
 	end
 
+	def place(ship, coordinates)
+		coordinates.each do |coordinate|
+			cell = @cells[coordinate]
+			cell.place_ship(ship)
+		end
+	end
 
 end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -66,4 +66,9 @@ class BoardTest < Minitest::Test
     assert third_cell.ship == second_cell.ship
   end
 
+  def test_it_cannot_overlap_placements_of_ships
+    @board.place(@cruiser, ["A1", "A2", "A3"])
+
+    refute @board.valid_placement?(@submarine, ["A1", "A2"])
+  end
 end


### PR DESCRIPTION
This PR brings in the .place method to the Board class, which allows a ship to be place on the cells required on the board.
The overlap placement test will check to confirm a Ship cannot be placed on the same cells where there is already a Ship.