### PR TITLE
Add overlap logic and extra overlap tests

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -19,6 +19,14 @@ class Board
     @cells.include?(cell)
 	end
 
+	def overlap_check(coordinates)
+		coordinates.each do |coordinate|
+			unless @cells[coordinate].empty?
+				return false
+			end
+		end
+	end
+
 	def valid_placement?(ship, coordinates)
 		if ship.length != coordinates.length
 			false
@@ -40,7 +48,9 @@ class Board
 			  end
 			end
 			###########################################
-			@hor_arr.any? {|valid| valid == coordinates} || @vert_arr.any? {|valid| valid == coordinates}
+			if @hor_arr.any? {|valid| valid == coordinates} || @vert_arr.any? {|valid| valid == coordinates}
+				overlap_check(coordinates)
+			end
 		elsif ship.length == 2
 			###########################################
 			# horizontal test
@@ -59,7 +69,9 @@ class Board
 			  end
 			end
 			###########################################
-			@hor_arr.any? {|valid| valid == coordinates} || @vert_arr.any? {|valid| valid == coordinates}
+			if @hor_arr.any? {|valid| valid == coordinates} || @vert_arr.any? {|valid| valid == coordinates}
+				overlap_check(coordinates)
+			end
 		else
 			raise ArgumentError.new("You messed up!")
 		end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -68,7 +68,9 @@ class BoardTest < Minitest::Test
 
   def test_it_cannot_overlap_placements_of_ships
     @board.place(@cruiser, ["A1", "A2", "A3"])
+    @board.place(@submarine, ["C4", "D4"])
 
     refute @board.valid_placement?(@submarine, ["A1", "A2"])
+    refute @board.valid_placement?(@cruiser, ["A4", "B4", "C4"])
   end
 end


### PR DESCRIPTION
This PR adds the logic to determine if a Ship can be placed in a Cell on the Board by determining if a Ship is already in that Cell. The logic is built into a helper method inside of the Board class.
We also added another assertion within the overlap test to confirm it works for both 2 and 3 size Ships, and horizontal and vertical placements.