### PR TITLE
Board render tests and method

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -5,6 +5,7 @@ class Board
 	def initialize(num)
 	   @cells = {}
      create_cells(num)
+		 @size = num
 	end
 
 	def create_cells(num)
@@ -65,8 +66,19 @@ class Board
 	end
 
 	def render(boolean = false)
-		# board_size = @cells.length
-"  1 2 3 4 \nA #{@cells["A1"].render(boolean)} #{@cells["A2"].render(boolean)} #{@cells["A3"].render(boolean)} #{@cells["A4"].render(boolean)} \nB #{@cells["B1"].render(boolean)} #{@cells["B2"].render(boolean)} #{@cells["B3"].render(boolean)} #{@cells["B4"].render(boolean)} \nC #{@cells["C1"].render(boolean)} #{@cells["C2"].render(boolean)} #{@cells["C3"].render(boolean)} #{@cells["C4"].render(boolean)} \nD #{@cells["D1"].render(boolean)} #{@cells["D2"].render(boolean)} #{@cells["D3"].render(boolean)} #{@cells["D4"].render(boolean)} \n"
+		display = "  "
+		@size.times do |width|
+			display += "#{width + 1} "
+		end
+		display += "\n"
+		@size.times do |width|
+			display += "#{(65 + width).chr} "
+			@size.times do |cell|
+				display += "#{@cells["#{(65 + width).chr}#{cell + 1}"].render(boolean)} "
+			end
+			display += "\n"
+		end
+		display
 	end
 
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -65,8 +65,8 @@ class Board
 	end
 
 	def render(boolean = false)
-		p "  1 2 3 4 \nA"
-# "  1 2 3 4 \nA . . . . \nB . . . . \nC . . . . \nD . . . . \n"
+		# board_size = @cells.length
+"  1 2 3 4 \nA #{@cells["A1"].render(boolean)} #{@cells["A2"].render(boolean)} #{@cells["A3"].render(boolean)} #{@cells["A4"].render(boolean)} \nB #{@cells["B1"].render(boolean)} #{@cells["B2"].render(boolean)} #{@cells["B3"].render(boolean)} #{@cells["B4"].render(boolean)} \nC #{@cells["C1"].render(boolean)} #{@cells["C2"].render(boolean)} #{@cells["C3"].render(boolean)} #{@cells["C4"].render(boolean)} \nD #{@cells["D1"].render(boolean)} #{@cells["D2"].render(boolean)} #{@cells["D3"].render(boolean)} #{@cells["D4"].render(boolean)} \n"
 	end
 
 end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -83,4 +83,10 @@ class BoardTest < Minitest::Test
     assert_equal "  1 2 3 4 \nA . . . . \nB . . . . \nC . . . . \nD . . . . \n", @board.render
     assert_equal "  1 2 3 4 \nA S S S . \nB . . . . \nC . . . . \nD . . . . \n", @board.render(true)
   end
+
+  def test_it_can_render_a_six_wide_board
+    board = Board.new(6)
+
+    assert_equal "  1 2 3 4 5 6 \nA . . . . . . \nB . . . . . . \nC . . . . . . \nD . . . . . . \n", board.render(true)
+  end
 end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -72,9 +72,15 @@ class BoardTest < Minitest::Test
     refute @board.valid_placement?(@cruiser, ["A4", "B4", "C4"])
   end
 
-  def test_if_board_can_render
+
+  def test_it_can_render_with_no_ships
+    assert_equal "  1 2 3 4 \nA . . . . \nB . . . . \nC . . . . \nD . . . . \n", @board.render(true)
+  end
+
+  def test_it_can_render_with_a_ship
     @board.place(@cruiser, ["A1", "A2", "A3"])
 
-    assert_equal "  1 2 3 4 \nA", @board.render
+    assert_equal "  1 2 3 4 \nA . . . . \nB . . . . \nC . . . . \nD . . . . \n", @board.render
+    assert_equal "  1 2 3 4 \nA S S S . \nB . . . . \nC . . . . \nD . . . . \n", @board.render(true)
   end
 end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -87,6 +87,6 @@ class BoardTest < Minitest::Test
   def test_it_can_render_a_six_wide_board
     board = Board.new(6)
 
-    assert_equal "  1 2 3 4 5 6 \nA . . . . . . \nB . . . . . . \nC . . . . . . \nD . . . . . . \n", board.render(true)
+    assert_equal "  1 2 3 4 5 6 \nA . . . . . . \nB . . . . . . \nC . . . . . . \nD . . . . . . \nE . . . . . . \nF . . . . . . \n", board.render(true)
   end
 end


### PR DESCRIPTION
This PR adds new tests for a `.render` method for the Board class, and said method.
Currently, the method is a little bit rough. Since it needs to display the whole Board, it needs to create each character based on the size of the Board, and then each Cell individually. Each Cell uses the `render` logic from the Cell class, so it needs to be called individually and added to our final display.
Currently the tests cover our base 4-wide size Board, and another 6-wide size board to confirm functionality.